### PR TITLE
Support extensions with mandatory config

### DIFF
--- a/src/Webfactory/Util/ApplicationServiceIterator.php
+++ b/src/Webfactory/Util/ApplicationServiceIterator.php
@@ -178,14 +178,16 @@ class ApplicationServiceIterator extends \FilterIterator
         }
         // Load the application configuration, which might affect the loaded services.
         $locator = new FileLocator($this->kernel);
-        $resolver = new LoaderResolver(array(
+        $loaders = array(
             new XmlFileLoader($builder, $locator),
             new YamlFileLoader($builder, $locator),
             new IniFileLoader($builder, $locator),
             new PhpFileLoader($builder, $locator),
-            new DirectoryLoader($builder, $locator),
+            (class_exists(DirectoryLoader::class) ? new DirectoryLoader($builder, $locator) : null),
             new ClosureLoader($builder),
-        ));
+        );
+        $loaders = array_filter($loaders);
+        $resolver = new LoaderResolver($loaders);
         $loader = new DelegatingLoader($resolver);
         $this->kernel->registerContainerConfiguration($loader);
         return $builder;

--- a/src/Webfactory/Util/ApplicationServiceIterator.php
+++ b/src/Webfactory/Util/ApplicationServiceIterator.php
@@ -2,9 +2,18 @@
 
 namespace Webfactory\Util;
 
+use Symfony\Component\Config\Loader\DelegatingLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
+use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
+use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -86,9 +95,9 @@ class ApplicationServiceIterator extends \FilterIterator
     protected function getIdsOfServicesThatAreDefinedInApplication()
     {
         if ($this->serviceIdWhitelist === null) {
-            $builder = new ContainerBuilder();
+            $builder = $this->createContainerBuilder();
             $this->applyToExtensions(function (ExtensionInterface $extension) use ($builder) {
-                $extension->load(array(), $builder);
+                $extension->load($builder->getExtensionConfig($extension->getAlias()), $builder);
             });
             $this->serviceIdWhitelist = $builder->getServiceIds();
         }
@@ -147,5 +156,38 @@ class ApplicationServiceIterator extends \FilterIterator
             }
         }
         return false;
+    }
+
+    /**
+     * Creates a pre-configured container builder.
+     *
+     * The builder contains all extensions and its configurations.
+     *
+     * @return ContainerBuilder
+     */
+    protected function createContainerBuilder()
+    {
+        $builder = new ContainerBuilder();
+        $this->kernel->boot();
+        foreach ($this->kernel->getBundles() as $bundle) {
+            // Register all extensions, otherwise there might be config parts that cannot be processed.
+            $extension = $bundle->getContainerExtension();
+            if ($extension !== null) {
+                $builder->registerExtension($extension);
+            }
+        }
+        // Load the application configuration, which might affect the loaded services.
+        $locator = new FileLocator($this->kernel);
+        $resolver = new LoaderResolver(array(
+            new XmlFileLoader($builder, $locator),
+            new YamlFileLoader($builder, $locator),
+            new IniFileLoader($builder, $locator),
+            new PhpFileLoader($builder, $locator),
+            new DirectoryLoader($builder, $locator),
+            new ClosureLoader($builder),
+        ));
+        $loader = new DelegatingLoader($resolver);
+        $this->kernel->registerContainerConfiguration($loader);
+        return $builder;
     }
 }

--- a/src/Webfactory/Util/ApplicationServiceIterator.php
+++ b/src/Webfactory/Util/ApplicationServiceIterator.php
@@ -2,6 +2,7 @@
 
 namespace Webfactory\Util;
 
+use Symfony\Component\Config\FileLocatorInterface;
 use Symfony\Component\Config\Loader\DelegatingLoader;
 use Symfony\Component\Config\Loader\LoaderResolver;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -13,7 +14,6 @@ use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\HttpKernel\Bundle\BundleInterface;
-use Symfony\Component\HttpKernel\Config\FileLocator;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 /**
@@ -177,7 +177,8 @@ class ApplicationServiceIterator extends \FilterIterator
             }
         }
         // Load the application configuration, which might affect the loaded services.
-        $locator = new FileLocator($this->kernel);
+        /* @var $locator FileLocatorInterface */
+        $locator = $this->kernel->getContainer()->get('file_locator');
         $loaders = array(
             new XmlFileLoader($builder, $locator),
             new YamlFileLoader($builder, $locator),

--- a/tests/_files/test-application/app/config/config_test.yml
+++ b/tests/_files/test-application/app/config/config_test.yml
@@ -12,6 +12,9 @@ framework:
     router: { resource: "%kernel.root_dir%/config/routing.yml" }
     templating: { engines: ['twig'] }
 
+webfactory_test:
+    required_parameter: "dummy"
+
 services:
     webfactory_test.uses_prefix_but_not_defined_in_bundle:
         class: stdClass

--- a/tests/_files/test-application/src/Webfactory/TestBundle/DependencyInjection/Configuration.php
+++ b/tests/_files/test-application/src/Webfactory/TestBundle/DependencyInjection/Configuration.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Webfactory\TestBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * Defines the configuration for this bundle.
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * @return TreeBuilder
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $rootNode = $treeBuilder->root('webfactory_test');
+
+        $rootNode
+            ->children()
+                ->scalarNode('required_parameter')
+                    ->isRequired()
+                    ->cannotBeEmpty()
+                    ->info('A required parameter without default value.')
+                ->end()
+            ->end()
+        ;
+
+        return $treeBuilder;
+    }
+}

--- a/tests/_files/test-application/src/Webfactory/TestBundle/DependencyInjection/WebfactoryTestExtension.php
+++ b/tests/_files/test-application/src/Webfactory/TestBundle/DependencyInjection/WebfactoryTestExtension.php
@@ -12,14 +12,14 @@ class WebfactoryTestExtension extends Extension
     /**
      * Loads service definitions.
      *
-     * @param array $configs
+     * @param array $config
      * @param ContainerBuilder $container
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $config, ContainerBuilder $container)
     {
         // Process the config, which checks if the required parameter is set.
         $configuration = new Configuration();
-        $this->processConfiguration($configuration, $configs);
+        $this->processConfiguration($configuration, $config);
 
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');

--- a/tests/_files/test-application/src/Webfactory/TestBundle/DependencyInjection/WebfactoryTestExtension.php
+++ b/tests/_files/test-application/src/Webfactory/TestBundle/DependencyInjection/WebfactoryTestExtension.php
@@ -17,6 +17,10 @@ class WebfactoryTestExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        // Process the config, which checks if the required parameter is set.
+        $configuration = new Configuration();
+        $this->processConfiguration($configuration, $configs);
+
         $loader = new YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
     }


### PR DESCRIPTION
Ensures that the tests can work with extensions that require config parameters (fixes #21).