### PR TITLE
Specify symfony/* dependencies instead of symfony/symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,15 @@
 
     "require": {
         "php": "^5.5.0 | ^7.0.0",
-        "symfony/symfony": "^2.3.0 | ^3.0.0",
+        "symfony/framework-bundle": "^2.3.0 | ^3.0.0",
+        "symfony/config": "^2.3.0 | ^3.0.0",
+        "symfony/dependency-injection": "^2.3.0 | ^3.0.0",
+        "symfony/event-dispatcher": "^2.3.0 | ^3.0.0",
+        "symfony/finder": "^2.3.0 | ^3.0.0",
+        "symfony/form": "^2.3.0 | ^3.0.0",
+        "symfony/http-foundation": "^2.3.0 | ^3.0.0",
+        "symfony/http-kernel": "^2.3.0 | ^3.0.0",
+        "symfony/routing": "^2.3.0 | ^3.0.0",
         "twig/twig": "~1.14",
         "jms/security-extra-bundle": "~1.5",
         "doctrine/common": "~2.4",


### PR DESCRIPTION
First guess based on the namespace imports found in this bundle.